### PR TITLE
Implement cardlanes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <!-- Include material icons for materialize css -->
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <title>bpd</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -13,6 +13,7 @@ class Branch {
     this.buildStatus = null;
     this.qualityGateStatus = null;
     this.coverage = null;
+    this.coverageChange = null;
     this.update();
   }
 
@@ -152,8 +153,10 @@ class Branch {
     try {
       const latestCoverallsInformation = this.apiClients["coveralls"].getCoverageInformationBySha(this.latestSha);
       this.coverage = parseFloat(latestCoverallsInformation["covered_percent"]);
+      this.coverageChange = parseFloat(latestCoverallsInformation["coverage_change"]);
     } catch (e) {
       this.coverage = null;
+      this.coverageChange = null;
     }
   }
   hasCoverage() {
@@ -165,6 +168,28 @@ class Branch {
   getCoverage() {
     if(this.hasCoverage()) {
       return (Math.round(this.coverage * 10) / 10).toString();
+    }
+    return "";
+  }
+  getCoverageChange() {
+    if(this.hasCoverage()) {
+      return (Math.round(this.coverageChange * 10) / 10).toString();
+    }
+    return "";
+  }
+  getNiceCoverage() {
+    var niceString = this.getCoverage();
+    if(niceString) {
+      return niceString + " %";
+    }
+    return "";
+  }
+  getNiceCoverageChange() {
+    var niceString = this.getCoverageChange();
+    if(niceString) {
+      if(!niceString.includes("-"))
+        niceString = "+" + niceString;
+      return niceString + " %";
     }
     return "";
   }

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -9,6 +9,7 @@ class Branch {
     // this.sonarqubeComponentId = this.apiClients["sonarqube"].getComponentIdForProject(this.getSonarqubeKey());
     this.latestCommitTimer = "";
     this.latestCommitter = "unknown";
+    this.latestCommitterAvatarUrl = "";
     this.latestSha = null;
     this.buildStatus = null;
     this.qualityGateStatus = null;
@@ -27,6 +28,7 @@ class Branch {
       const latestInformation = this.apiClients["gitHub"].getDetailsAboutBranch(this.getRepositoryUrl(), this.getName());
       this.latestCommitTimer = new Date(latestInformation["commit"]["commit"]["author"]["date"]);
       this.latestCommitter = latestInformation["commit"]["commit"]["author"]["name"];
+      this.latestCommitterAvatarUrl = latestInformation["commit"]["author"]["avatar_url"];
       this.latestSha = latestInformation["commit"]["sha"];
     } catch (e) {
       return 1;
@@ -57,6 +59,9 @@ class Branch {
   }
   getLatestCommitter() {
     return this.latestCommitter;
+  }
+  getLatestCommitterAvatarUrl() {
+    return this.latestCommitterAvatarUrl;
   }
   isDeveloperBranch() {
     return (this.getName() == "dev" || this.getName() == "developer");

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -55,6 +55,9 @@ class Branch {
   getLastCommitTimeAsString() {
     return this.getLastCommitTime().toLocaleString();
   }
+  getLatestCommitter() {
+    return this.latestCommitter;
+  }
   isDeveloperBranch() {
     return (this.getName() == "dev" || this.getName() == "developer");
   }

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.css
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.css
@@ -1,3 +1,7 @@
+.card-title {
+  word-wrap: break-word;
+}
+
 .status-lanes {
   position: absolute;
   bottom: 0px;

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.css
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.css
@@ -1,6 +1,11 @@
-.cardlane {
+.status-lanes {
   position: absolute;
+  bottom: 0px;
   left: 0px;
   right: 0px;
+}
+
+.card-lane {
+  color: white;
   padding: 10px 24px 10px 24px;
 }

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.css
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.css
@@ -1,0 +1,6 @@
+.cardlane {
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  padding: 10px 24px 10px 24px;
+}

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.css
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.css
@@ -6,6 +6,5 @@
 }
 
 .card-lane {
-  color: white;
-  padding: 10px 24px 10px 24px;
+  min-height: 30px;
 }

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.js
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.js
@@ -65,7 +65,7 @@ class BranchCard extends Component {
             <div className="status-lanes">
               <TextLane value={this.branch.getLastCommitTimeAsString()} />
               <TextLane value={this.branch.getLatestCommitter()} />
-              <ProgressLane value={this.branch.getCoverage()} valueText={this.branch.getNiceCoverage()} changeText={this.branch.getNiceCoverageChange()} />
+              <ProgressLane value={this.branch.getCoverage()} valueText={this.branch.getNiceCoverage()} changeText={this.branch.getNiceCoverageChange()} showLabels={false} />
               <TextLane value={`</> ${this.branch.getNiceSonarqubeString()}`} color={this.getColorBasedOnQualityGate()} />
             </div>
           </div>

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.js
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.js
@@ -56,13 +56,6 @@ class BranchCard extends Component {
     }
   }
 
-  displayCoverage() {
-    if(this.branch.hasCoverage()) {
-      return " | " + this.branch.getCoverage() + " %";
-    }
-    return "";
-  }
-
   render() {
     return (
       <div className="col s2" key={this.branch.getName()} >
@@ -71,7 +64,8 @@ class BranchCard extends Component {
             <span className="card-title">{this.getTitleForCard()}</span>
             <div className="status-lanes">
               <TextLane value={this.branch.getLastCommitTimeAsString()} />
-                <TextLane value={`</> ${this.branch.getNiceSonarqubeString()} ${this.displayCoverage()}`} color={this.getColorBasedOnQualityGate()} />
+              <ProgressLane value={this.branch.getCoverage()} valueText={this.branch.getNiceCoverage()} changeText={this.branch.getNiceCoverageChange()} />
+              <TextLane value={`</> ${this.branch.getNiceSonarqubeString()}`} color={this.getColorBasedOnQualityGate()} />
             </div>
           </div>
         </div>

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.js
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.js
@@ -63,8 +63,8 @@ class BranchCard extends Component {
           <div className="card-content white-text">
             <span className="card-title">{this.getTitleForCard()}</span>
             <div className="status-lanes">
-              <TextLane value={this.branch.getLastCommitTimeAsString()} />
-              <TextLane value={this.branch.getLatestCommitter()} />
+              <TextLane value={this.branch.getLastCommitTimeAsString()} textColor="grey-text text-lighten-2" />
+              <TextLane value={this.branch.getLatestCommitter()} textColor="grey-text text-lighten-2" />
               <ProgressLane value={this.branch.getCoverage()} valueText={this.branch.getNiceCoverage()} changeText={this.branch.getNiceCoverageChange()} showLabels={false} />
               <TextLane value={`</> ${this.branch.getNiceSonarqubeString()}`} color={this.getColorBasedOnQualityGate()} />
             </div>

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.js
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.js
@@ -64,6 +64,7 @@ class BranchCard extends Component {
             <span className="card-title">{this.getTitleForCard()}</span>
             <div className="status-lanes">
               <TextLane value={this.branch.getLastCommitTimeAsString()} />
+              <TextLane value={this.branch.getLatestCommitter()} />
               <ProgressLane value={this.branch.getCoverage()} valueText={this.branch.getNiceCoverage()} changeText={this.branch.getNiceCoverageChange()} />
               <TextLane value={`</> ${this.branch.getNiceSonarqubeString()}`} color={this.getColorBasedOnQualityGate()} />
             </div>

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.js
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import TextLane from './CardLanes/TextLane/TextLane.js';
 import ProgressLane from './CardLanes/ProgressLane/ProgressLane.js';
+import UserLane from './CardLanes/UserLane/UserLane.js';
 import './BranchCard.css';
 
 class BranchCard extends Component {
@@ -64,7 +65,7 @@ class BranchCard extends Component {
             <span className="card-title">{this.getTitleForCard()}</span>
             <div className="status-lanes">
               <TextLane value={this.branch.getLastCommitTimeAsString()} textColor="grey-text text-lighten-2" />
-              <TextLane value={this.branch.getLatestCommitter()} textColor="grey-text text-lighten-2" />
+              <UserLane username={this.branch.getLatestCommitter()} avatarUrl={this.branch.getLatestCommitterAvatarUrl()} />
               <ProgressLane value={this.branch.getCoverage()} valueText={this.branch.getNiceCoverage()} changeText={this.branch.getNiceCoverageChange()} showLabels={false} />
               <TextLane value={`</> ${this.branch.getNiceSonarqubeString()}`} color={this.getColorBasedOnQualityGate()} />
             </div>

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.js
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import TextLane from './CardLanes/TextLane/TextLane.js';
+import ProgressLane from './CardLanes/ProgressLane/ProgressLane.js';
 import './BranchCard.css';
 
 class BranchCard extends Component {
@@ -67,10 +69,9 @@ class BranchCard extends Component {
         <div className={`card small horizontal ${this.getColorBasedOnLatestBuild()}`}>
           <div className="card-content white-text">
             <span className="card-title">{this.getTitleForCard()}</span>
-            {this.branch.getLastCommitTimeAsString()}
-            <br />
-            <div className={`card-action ${this.getColorBasedOnQualityGate()}`}>
-                {`</> ${this.branch.getNiceSonarqubeString()} ${this.displayCoverage()}`}
+            <div className="status-lanes">
+              <TextLane value={this.branch.getLastCommitTimeAsString()} />
+                <TextLane value={`</> ${this.branch.getNiceSonarqubeString()} ${this.displayCoverage()}`} color={this.getColorBasedOnQualityGate()} />
             </div>
           </div>
         </div>

--- a/src/Overview/ProjectLane/BranchCard/BranchCard.js
+++ b/src/Overview/ProjectLane/BranchCard/BranchCard.js
@@ -60,7 +60,7 @@ class BranchCard extends Component {
   render() {
     return (
       <div className="col s2" key={this.branch.getName()} >
-        <div className={`card small horizontal ${this.getColorBasedOnLatestBuild()}`}>
+        <div className={`card small horizontal hoverable ${this.getColorBasedOnLatestBuild()}`}>
           <div className="card-content white-text">
             <span className="card-title">{this.getTitleForCard()}</span>
             <div className="status-lanes">

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.css
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.css
@@ -6,7 +6,10 @@
 
 .progress-card-lane-base, .progress-card-lane-bar {
   flex-grow: 1;
-  padding: 10px 24px 10px 24px;
+  overflow: hidden;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  box-sizing: border-box;
 }
 .progress-card-lane-bar {
   z-index: 2;
@@ -16,15 +19,16 @@
   z-index: 1;
 }
 
-
-/*.progress-card-lane-base, .progress-card-lane-bar {
-  flex-grow: 1;
-  padding: 10px 24px 10px 24px;
-}
-.progress-card-lane-bar {
-  z-index: 2;
+.progress-card-lane-bar-content, .progress-card-lane-base-content {
+  font-style: italic;
+  font-size: 12px;
 }
 
-.progress-card-lane-base {
-  z-index: 1;
-}*/
+.progress-card-lane-base-content {
+  padding-left: 10px;
+  padding-right: 24px;
+}
+
+.progress-card-lane-bar-content {
+  padding-left: 24px;
+}

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.css
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.css
@@ -1,0 +1,30 @@
+.progress-card-lane {
+  display: flex;
+  flex-direction: row;
+  white-space: nowrap;
+}
+
+.progress-card-lane-base, .progress-card-lane-bar {
+  flex-grow: 1;
+  padding: 10px 24px 10px 24px;
+}
+.progress-card-lane-bar {
+  z-index: 2;
+}
+
+.progress-card-lane-base {
+  z-index: 1;
+}
+
+
+/*.progress-card-lane-base, .progress-card-lane-bar {
+  flex-grow: 1;
+  padding: 10px 24px 10px 24px;
+}
+.progress-card-lane-bar {
+  z-index: 2;
+}
+
+.progress-card-lane-base {
+  z-index: 1;
+}*/

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import './ProgressLane.css';
+
+class ProgressLane extends Component {
+  constructor(props) {
+    super(props);
+
+  }
+  componentDidMount() {
+
+  }
+
+
+  render() {
+    return (
+      <div className="cardlane">
+        ProgressLane
+      </div>
+    );
+  }
+
+}
+
+export default ProgressLane;

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
@@ -13,7 +13,7 @@ class ProgressLane extends Component {
 
   render() {
     return (
-      <div className="cardlane">
+      <div className="card-lane">
         ProgressLane
       </div>
     );

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
@@ -29,16 +29,29 @@ class ProgressLane extends Component {
     }
   }
 
+  getChangeTextColor() {
+    if(this.state.changeText.includes("+")) {
+      return "green-text text-darken-4";
+    }
+    if(this.state.changeText.includes("-")) {
+      return "red-text text-darken-4";
+    }
+  }
+
 
   render() {
-    // <div className={`progress-card-lane-bar z-depth-2 ${this.state.progressColor}`} style={{flex: `0 0 ${this.state.value}%`}}>{this.state.valueText}</div>
-    // <div className={`progress-card-lane-base  ${this.state.baseColor}`}>{this.state.changeText}</div>
-
     return (
       <div className="card-lane progress-card-lane " >
-        
-        <div className={`progress-card-lane-bar z-depth-2 ${this.state.progressColor}`} style={{flex: `0 0 ${this.state.value}%`}}></div>
-        <div className={`progress-card-lane-base  ${this.state.baseColor}`} style={{flex: `1 0`}}></div>
+        <div className={`progress-card-lane-bar z-depth-2 ${this.state.progressColor}`} style={{flex: `0 0 ${this.state.value}%`}}>
+          <span className="progress-card-lane-bar-content teal-text text-accent-2">
+            {this.state.valueText}
+          </span>
+        </div>
+        <div className={`progress-card-lane-base  ${this.state.baseColor}`} style={{flex: `1 0`}}>
+          <span className={`progress-card-lane-base-content ${this.getChangeTextColor()}`}>
+            {this.state.changeText}
+          </span>
+        </div>
       </div>
     );
   }

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
@@ -4,17 +4,41 @@ import './ProgressLane.css';
 class ProgressLane extends Component {
   constructor(props) {
     super(props);
-
+    let value = 0;
+    if(this.props.value) {
+      value = this.props.value;
+    }
+    this.state = {baseColor: 'teal lighten-2',
+        progressColor: 'teal',
+        valueText: ' ',
+        changeText: ' ',
+        value: value};
   }
   componentDidMount() {
-
+    if(this.props.baseColor) {
+      this.setState({baseColor: this.props.baseColor});
+    }
+    if(this.props.progressColor) {
+      this.setState({progressColor: this.props.progressColor});
+    }
+    if(this.props.valueText) {
+      this.setState({valueText: this.props.valueText});
+    }
+    if(this.props.changeText) {
+      this.setState({changeText: this.props.changeText});
+    }
   }
 
 
   render() {
+    // <div className={`progress-card-lane-bar z-depth-2 ${this.state.progressColor}`} style={{flex: `0 0 ${this.state.value}%`}}>{this.state.valueText}</div>
+    // <div className={`progress-card-lane-base  ${this.state.baseColor}`}>{this.state.changeText}</div>
+
     return (
-      <div className="card-lane">
-        ProgressLane
+      <div className="card-lane progress-card-lane " >
+        
+        <div className={`progress-card-lane-bar z-depth-2 ${this.state.progressColor}`} style={{flex: `0 0 ${this.state.value}%`}}></div>
+        <div className={`progress-card-lane-base  ${this.state.baseColor}`} style={{flex: `1 0`}}></div>
       </div>
     );
   }

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/ProgressLane/ProgressLane.js
@@ -21,10 +21,10 @@ class ProgressLane extends Component {
     if(this.props.progressColor) {
       this.setState({progressColor: this.props.progressColor});
     }
-    if(this.props.valueText) {
+    if(this.props.valueText && this.props.showLabels) {
       this.setState({valueText: this.props.valueText});
     }
-    if(this.props.changeText) {
+    if(this.props.changeText && this.props.showLabels) {
       this.setState({changeText: this.props.changeText});
     }
   }

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.css
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.css
@@ -1,0 +1,4 @@
+.text-card-lane {
+  color: white;
+  padding: 10px 24px 10px 24px;
+}

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
@@ -7,18 +7,21 @@ class TextLane extends Component {
     this.state = {text: this.props.value};
   }
   componentDidMount() {
-
+    if(this.props.color) {
+      this.setState({color: this.props.color});
+    }
+    else {
+      this.setState({color: ""});
+    }
   }
-
 
   render() {
     return (
-      <div className={`card-lane ${this.props.color}`}>
+      <div className={`card-lane text-card-lane ${this.state.color}`}>
         {this.state.text}
       </div>
     );
   }
-
 }
 
 export default TextLane;

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import './TextLane.css';
+
+class TextLane extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {text: this.props.text};
+  }
+  componentDidMount() {
+
+  }
+
+
+  render() {
+    return (
+      <div className="cardlane">
+        {this.state.text}
+      </div>
+    );
+  }
+
+}
+
+export default TextLane;

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
@@ -4,7 +4,7 @@ import './TextLane.css';
 class TextLane extends Component {
   constructor(props) {
     super(props);
-    this.state = {text: this.props.text};
+    this.state = {text: this.props.value};
   }
   componentDidMount() {
 
@@ -13,7 +13,7 @@ class TextLane extends Component {
 
   render() {
     return (
-      <div className="cardlane">
+      <div className={`card-lane ${this.props.color}`}>
         {this.state.text}
       </div>
     );

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
@@ -4,20 +4,28 @@ import './TextLane.css';
 class TextLane extends Component {
   constructor(props) {
     super(props);
-    this.state = {text: this.props.value};
+    this.state = {text: this.props.value,
+        backgroundColor: "",
+        textColor: ""};
   }
   componentDidMount() {
     if(this.props.color) {
       this.setState({backgroundColor: this.props.color});
     }
-    else {
-      this.setState({color: ""});
+    if(this.props.textColor) {
+      this.setState({textColor: this.props.textColor});
     }
+  }
+  getStyle() {
+    if(this.props.italic) {
+      return {fontStyle: 'italic'};
+    }
+    return {};
   }
 
   render() {
     return (
-      <div className={`card-lane text-card-lane ${this.state.backgroundColor}`}>
+      <div className={`card-lane text-card-lane ${this.state.backgroundColor} ${this.state.textColor}`} style={this.getStyle()}>
         {this.state.text}
       </div>
     );

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/TextLane/TextLane.js
@@ -8,7 +8,7 @@ class TextLane extends Component {
   }
   componentDidMount() {
     if(this.props.color) {
-      this.setState({color: this.props.color});
+      this.setState({backgroundColor: this.props.color});
     }
     else {
       this.setState({color: ""});
@@ -17,7 +17,7 @@ class TextLane extends Component {
 
   render() {
     return (
-      <div className={`card-lane text-card-lane ${this.state.color}`}>
+      <div className={`card-lane text-card-lane ${this.state.backgroundColor}`}>
         {this.state.text}
       </div>
     );

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/UserLane/UserLane.css
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/UserLane/UserLane.css
@@ -1,0 +1,8 @@
+.user-card-lane {
+  color: white;
+  padding: 5px 24px 10px 24px;
+}
+
+.user-card-lane .chip {
+  margin-bottom: 0px;
+}

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/UserLane/UserLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/UserLane/UserLane.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import './UserLane.css';
+
+class UserLane extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {username: this.props.username,
+        avatarUrl: ""};
+  }
+  componentDidMount() {
+    if(this.props.avatarUrl) {
+      this.setState({avatarUrl: this.props.avatarUrl});
+    }
+  }
+
+  render() {
+    return (
+      <div className="card-lane user-card-lane">
+        <div className="chip"><img src={this.state.avatarUrl} alt="Contact Person" />{this.state.username}</div>
+      </div>
+    );
+  }
+}
+
+export default UserLane;

--- a/src/Overview/ProjectLane/BranchCard/CardLanes/UserLane/UserLane.js
+++ b/src/Overview/ProjectLane/BranchCard/CardLanes/UserLane/UserLane.js
@@ -5,7 +5,7 @@ class UserLane extends Component {
   constructor(props) {
     super(props);
     this.state = {username: this.props.username,
-        avatarUrl: ""};
+        avatarUrl: "https://upload.wikimedia.org/wikipedia/commons/d/d2/Blank.png"};
   }
   componentDidMount() {
     if(this.props.avatarUrl) {
@@ -16,7 +16,7 @@ class UserLane extends Component {
   render() {
     return (
       <div className="card-lane user-card-lane">
-        <div className="chip"><img src={this.state.avatarUrl} alt="Contact Person" />{this.state.username}</div>
+        <div className="chip"><img src={this.state.avatarUrl} />{this.state.username}</div>
       </div>
     );
   }


### PR DESCRIPTION
We now have lane-components to be used in materialize-css cards.
Currently there are lanes for:
 * simple text (well, to be honest, it just shows stupid, boring text! Hey but wait: you can even change its color, and, surprise, its background color too! And if you try hard enough you might even get an _italic_ formatted text. Hint: Try tickling it!)
 * progress (colored bar, can also show progress and progress-change in labels)
 * users with their avatar (showing a picture and username)
