### PR TITLE
Hotfix for status information

### DIFF
--- a/src/Branch.js
+++ b/src/Branch.js
@@ -45,7 +45,7 @@ class Branch {
         const outdated = lastCommitTime < this.getLastCommitTime();
 
         if (outdated) {
-            this.resetServiceStatus()
+            this.resetServiceStatus();
         }
 
         if (!this.getBuildStatus()) {
@@ -85,29 +85,29 @@ class Branch {
         return this.latestCommitterAvatarUrl;
     }
     isDeveloperBranch() {
-        return (this.getName() == "dev" || this.getName() == "developer");
+        return (this.getName() === "dev" || this.getName() === "developer");
     }
     isMasterBranch() {
-        return (this.getName() == "master");
+        return (this.getName() === "master");
     }
     isIssueExtractable() {
         const ret = this.branchPattern.exec(this.getName());
-        if(ret) {
+        if (ret) {
             return true;
         }
         return false;
     }
     getIssueNumber() {
         const ret = this.branchPattern.exec(this.getName());
-        if(ret){
+        if (ret){
             return ret[1];
         }
         return "";
     }
     getIssueName() {
         const ret = this.branchPattern.exec(this.getName());
-        if(ret){
-            var unformattedName = ret[2];
+        if (ret){
+            let unformattedName = ret[2];
             unformattedName = unformattedName.replace(/\_/g, " ");
             unformattedName = unformattedName.replace(/\-/g, " ");
             return unformattedName;
@@ -137,8 +137,8 @@ class Branch {
         }
     }
     getSonarqubeKey() {
-        var sonarqubeKey = "de.hpi.bpt:" + this.getRepository();
-        if(!this.isMasterBranch())
+        let sonarqubeKey = "de.hpi.bpt:" + this.getRepository();
+        if (!this.isMasterBranch())
             sonarqubeKey += ":" + this.getName();
         return sonarqubeKey;
     }
@@ -146,12 +146,12 @@ class Branch {
         return this.qualityGateStatus;
     }
     doesPassQualityGate() {
-        return (!(this.getQualityGateStatus() == "ERROR"));
+        return (!(this.getQualityGateStatus() === "ERROR"));
     }
     getNiceSonarqubeString() {
-        if(!this.didSonarqubeRun())
+        if (!this.didSonarqubeRun())
             return "no results";
-        if(this.doesPassQualityGate()) {
+        if (this.doesPassQualityGate()) {
             return "QG passed";
         }
         else {
@@ -189,7 +189,7 @@ class Branch {
 
     //COVERALLS FUNCTIONS
     updateCoverallsInformation() {
-        if(!this.latestSha) {
+        if (!this.latestSha) {
             return;
         }
         try {
@@ -207,29 +207,30 @@ class Branch {
         return false;
     }
     getCoverage() {
-        if(this.hasCoverage()) {
+        if (this.hasCoverage()) {
             return (Math.round(this.coverage * 10) / 10).toString();
         }
         return "";
     }
     getCoverageChange() {
-        if(this.hasCoverage()) {
+        if (this.hasCoverage()) {
             return (Math.round(this.coverageChange * 10) / 10).toString();
         }
         return "";
     }
     getNiceCoverage() {
-        var niceString = this.getCoverage();
-        if(niceString) {
+        const niceString = this.getCoverage();
+        if (niceString) {
             return niceString + " %";
         }
         return "";
     }
     getNiceCoverageChange() {
-        var niceString = this.getCoverageChange();
-        if(niceString) {
-            if(!niceString.includes("-"))
+        let niceString = this.getCoverageChange();
+        if (niceString) {
+            if (!niceString.includes("-")) {
                 niceString = "+" + niceString;
+            }
             return niceString + " %";
         }
         return "";

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -1,5 +1,12 @@
 class Branch {
 
+    /**
+     * Represents a branch in GitHub. Contains latest meta information and the status of connected services.
+     *
+     * @param branchName a string containing the name of the branch
+     * @param repositoryUrl a string identifying the repository the branch belongs to (organization|username/repositoryname)
+     * @param apiClients an array with all available api clients
+     */
     constructor(branchName, repositoryUrl, apiClients) {
         this.name = branchName;
         this.owner = repositoryUrl.split("/")[0];
@@ -20,7 +27,8 @@ class Branch {
 
     /**
      * Fetches information from GitHub-API and parses returned JSON
-     * to reset attribute-values.
+     * to reset attribute-values. If the branch was updated, all service information will be reset.
+     * If no service status are available, it will be tried to fetch the latest information.
      *
      */
     update() {
@@ -110,6 +118,9 @@ class Branch {
         return ("https://bpt-lab.org/jira/secure/RapidBoard.jspa?rapidView=8&view=detail&selectedIssue=BP-" + this.getIssueNumber());
     }
 
+    /**
+     * Resets information if all services (e.g. Travis).
+     */
     resetServiceStatus() {
         this.resetSonarqubeInformation();
         this.resetTravisInformation();

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -1,215 +1,232 @@
 class Branch {
 
-  constructor(branchName, repositoryUrl, apiClients) {
-    this.name = branchName;
-    this.owner = repositoryUrl.split("/")[0];
-    this.repository = repositoryUrl.split("/")[1];
-    this.apiClients = apiClients;
-    this.branchPattern = /BP[\-|\_](\d{0,4})[\-|\_](.+)/;
-    // this.sonarqubeComponentId = this.apiClients["sonarqube"].getComponentIdForProject(this.getSonarqubeKey());
-    this.latestCommitTimer = "";
-    this.latestCommitter = "unknown";
-    this.latestCommitterAvatarUrl = "";
-    this.latestSha = null;
-    this.buildStatus = null;
-    this.qualityGateStatus = null;
-    this.coverage = null;
-    this.coverageChange = null;
-    this.update();
-  }
+    constructor(branchName, repositoryUrl, apiClients) {
+        this.name = branchName;
+        this.owner = repositoryUrl.split("/")[0];
+        this.repository = repositoryUrl.split("/")[1];
+        this.apiClients = apiClients;
+        this.branchPattern = /BP[\-|\_](\d{0,4})[\-|\_](.+)/;
+        // this.sonarqubeComponentId = this.apiClients["sonarqube"].getComponentIdForProject(this.getSonarqubeKey());
+        this.latestCommitTimer = "";
+        this.latestCommitter = "unknown";
+        this.latestCommitterAvatarUrl = "";
+        this.latestSha = null;
+        this.buildStatus = null;
+        this.qualityGateStatus = null;
+        this.coverage = null;
+        this.coverageChange = null;
+        this.update();
+    }
 
-  /**
-  * Fetches information from GitHub-API and parses returned JSON
-  * to reset attribute-values.
-  *
-  */
-  update() {
-      const lastCommitTime = this.getLastCommitTime();
-    try {
-      const latestInformation = this.apiClients["gitHub"].getDetailsAboutBranch(this.getRepositoryUrl(), this.getName());
-      this.latestCommitTimer = new Date(latestInformation["commit"]["commit"]["author"]["date"]);
-      this.latestCommitter = latestInformation["commit"]["commit"]["author"]["name"];
-      this.latestCommitterAvatarUrl = latestInformation["commit"]["author"]["avatar_url"];
-      this.latestSha = latestInformation["commit"]["sha"];
-    } catch (e) {
-      return 1;
-    }
-    const outdated = lastCommitTime < this.getLastCommitTime();
+    /**
+     * Fetches information from GitHub-API and parses returned JSON
+     * to reset attribute-values.
+     *
+     */
+    update() {
+        const lastCommitTime = this.getLastCommitTime();
+        try {
+            const latestInformation = this.apiClients["gitHub"].getDetailsAboutBranch(this.getRepositoryUrl(), this.getName());
+            this.latestCommitTimer = new Date(latestInformation["commit"]["commit"]["author"]["date"]);
+            this.latestCommitter = latestInformation["commit"]["commit"]["author"]["name"];
+            this.latestCommitterAvatarUrl = latestInformation["commit"]["author"]["avatar_url"];
+            this.latestSha = latestInformation["commit"]["sha"];
+        } catch (e) {
+            return 1;
+        }
+        const outdated = lastCommitTime < this.getLastCommitTime();
 
-    if (!this.getBuildStatus() || outdated) {
-        this.updateTravisInformation();
+        if (outdated) {
+            this.resetServiceStatus()
+        }
+
+        if (!this.getBuildStatus()) {
+            this.updateTravisInformation();
+        }
+        if (!this.getQualityGateStatus()) {
+            this.updateSonarqubeInformation();
+        }
+        if (!this.getCoverage()) {
+            this.updateCoverallsInformation();
+        }
     }
-    if (!this.getQualityGateStatus() || outdated) {
-        this.updateSonarqubeInformation();
-    }
-    if (!this.getCoverage() || outdated) {
-        this.updateCoverallsInformation();
-    }
-  }
 
 
-  getName() {
-    return this.name;
-  }
-  getOwner() {
-    return this.owner;
-  }
-  getRepository() {
-    return this.repository;
-  }
-  getRepositoryUrl() {
-    return this.getOwner() + "/" + this.getRepository();
-  }
-  getLastCommitTime() {
-    return this.latestCommitTimer;
-  }
-  getLastCommitTimeAsString() {
-    return this.getLastCommitTime().toLocaleString();
-  }
-  getLatestCommitter() {
-    return this.latestCommitter;
-  }
-  getLatestCommitterAvatarUrl() {
-    return this.latestCommitterAvatarUrl;
-  }
-  isDeveloperBranch() {
-    return (this.getName() == "dev" || this.getName() == "developer");
-  }
-  isMasterBranch() {
-    return (this.getName() == "master");
-  }
-  isIssueExtractable() {
-    const ret = this.branchPattern.exec(this.getName());
-    if(ret) {
-      return true;
+    getName() {
+        return this.name;
     }
-    return false;
-  }
-  getIssueNumber() {
-    const ret = this.branchPattern.exec(this.getName());
-    if(ret){
-      return ret[1];
+    getOwner() {
+        return this.owner;
     }
-    return "";
-  }
-  getIssueName() {
-    const ret = this.branchPattern.exec(this.getName());
-    if(ret){
-      var unformattedName = ret[2];
-      unformattedName = unformattedName.replace(/\_/g, " ");
-      unformattedName = unformattedName.replace(/\-/g, " ");
-      return unformattedName;
+    getRepository() {
+        return this.repository;
     }
-    return "";
-  }
-  getJiraLink() {
-    return ("https://bpt-lab.org/jira/secure/RapidBoard.jspa?rapidView=8&view=detail&selectedIssue=BP-" + this.getIssueNumber());
-  }
+    getRepositoryUrl() {
+        return this.getOwner() + "/" + this.getRepository();
+    }
+    getLastCommitTime() {
+        return this.latestCommitTimer;
+    }
+    getLastCommitTimeAsString() {
+        return this.getLastCommitTime().toLocaleString();
+    }
+    getLatestCommitter() {
+        return this.latestCommitter;
+    }
+    getLatestCommitterAvatarUrl() {
+        return this.latestCommitterAvatarUrl;
+    }
+    isDeveloperBranch() {
+        return (this.getName() == "dev" || this.getName() == "developer");
+    }
+    isMasterBranch() {
+        return (this.getName() == "master");
+    }
+    isIssueExtractable() {
+        const ret = this.branchPattern.exec(this.getName());
+        if(ret) {
+            return true;
+        }
+        return false;
+    }
+    getIssueNumber() {
+        const ret = this.branchPattern.exec(this.getName());
+        if(ret){
+            return ret[1];
+        }
+        return "";
+    }
+    getIssueName() {
+        const ret = this.branchPattern.exec(this.getName());
+        if(ret){
+            var unformattedName = ret[2];
+            unformattedName = unformattedName.replace(/\_/g, " ");
+            unformattedName = unformattedName.replace(/\-/g, " ");
+            return unformattedName;
+        }
+        return "";
+    }
+    getJiraLink() {
+        return ("https://bpt-lab.org/jira/secure/RapidBoard.jspa?rapidView=8&view=detail&selectedIssue=BP-" + this.getIssueNumber());
+    }
 
-  //SONARQUBE FUNCTIONS
+    resetServiceStatus() {
+        this.resetSonarqubeInformation();
+        this.resetTravisInformation();
+        this.resetCoverallsInformation();
+    }
 
-  updateSonarqubeInformation() {
-    try {
-      this.qualityGateStatus = this.apiClients["sonarqube"].getQualityGateStatusForProject(this.getSonarqubeKey());
-    } catch (e) {
+    //SONARQUBE FUNCTIONS
+
+    updateSonarqubeInformation() {
+        try {
+            this.qualityGateStatus = this.apiClients["sonarqube"].getQualityGateStatusForProject(this.getSonarqubeKey());
+        } catch (e) {
+            this.resetSonarqubeInformation();
+        }
+    }
+    getSonarqubeKey() {
+        var sonarqubeKey = "de.hpi.bpt:" + this.getRepository();
+        if(!this.isMasterBranch())
+            sonarqubeKey += ":" + this.getName();
+        return sonarqubeKey;
+    }
+    getQualityGateStatus() {
+        return this.qualityGateStatus;
+    }
+    doesPassQualityGate() {
+        return (!(this.getQualityGateStatus() == "ERROR"));
+    }
+    getNiceSonarqubeString() {
+        if(!this.didSonarqubeRun())
+            return "no results";
+        if(this.doesPassQualityGate()) {
+            return "QG passed";
+        }
+        else {
+            return "QG failed";
+        }
+    }
+    didSonarqubeRun() {
+        return (this.qualityGateStatus);
+    }
+    resetSonarqubeInformation() {
         this.qualityGateStatus = null;
     }
-  }
 
-  getSonarqubeKey() {
-    var sonarqubeKey = "de.hpi.bpt:" + this.getRepository();
-    if(!this.isMasterBranch())
-      sonarqubeKey += ":" + this.getName();
-    return sonarqubeKey;
-  }
-  getQualityGateStatus() {
-    return this.qualityGateStatus;
-  }
-  doesPassQualityGate() {
-    return (!(this.getQualityGateStatus() == "ERROR"));
-  }
-  getNiceSonarqubeString() {
-    if(!this.didSonarqubeRun())
-      return "no results";
-    if(this.doesPassQualityGate()) {
-      return "QG passed";
+    //TRAVIS FUNCTIONS
+    updateTravisInformation() {
+        try {
+            const latestBuildInformation = this.apiClients["travis"].getDetailsAboutLatestBuildOfBranch(this.getRepositoryUrl(), this.getName());
+            this.buildStatus = latestBuildInformation["branch"]["state"];
+        } catch (e) {
+            this.resetTravisInformation();
+        }
     }
-    else {
-      return "QG failed";
+    getBuildStatus() {
+        return this.buildStatus;
     }
-  }
-  didSonarqubeRun() {
-    return (this.qualityGateStatus);
-  }
-
-  //TRAVIS FUNCTIONS
-  updateTravisInformation() {
-    try {
-      const latestBuildInformation = this.apiClients["travis"].getDetailsAboutLatestBuildOfBranch(this.getRepositoryUrl(), this.getName());
-      this.buildStatus = latestBuildInformation["branch"]["state"];
-    } catch (e) {
+    didLatestBuildPass() {
+        return (this.getBuildStatus() === "passed");
+    }
+    didTravisRun() {
+        return (this.buildStatus);
+    }
+    resetTravisInformation() {
         this.buildStatus = null;
     }
-  }
 
-  getBuildStatus() {
-    return this.buildStatus;
-  }
-  didLatestBuildPass() {
-    return (this.getBuildStatus() == "passed");
-  }
-  didTravisRun() {
-    return (this.buildStatus);
-  }
-
-  //COVERALLS FUNCTIONS
-  updateCoverallsInformation() {
-    if(!this.latestSha) {
-      return;
+    //COVERALLS FUNCTIONS
+    updateCoverallsInformation() {
+        if(!this.latestSha) {
+            return;
+        }
+        try {
+            const latestCoverallsInformation = this.apiClients["coveralls"].getCoverageInformationBySha(this.latestSha);
+            this.coverage = parseFloat(latestCoverallsInformation["covered_percent"]);
+            this.coverageChange = parseFloat(latestCoverallsInformation["coverage_change"]);
+        } catch (e) {
+            this.resetCoverallsInformation();
+        }
     }
-    try {
-      const latestCoverallsInformation = this.apiClients["coveralls"].getCoverageInformationBySha(this.latestSha);
-      this.coverage = parseFloat(latestCoverallsInformation["covered_percent"]);
-      this.coverageChange = parseFloat(latestCoverallsInformation["coverage_change"]);
-    } catch (e) {
-      this.coverage = null;
-      this.coverageChange = null;
+    hasCoverage() {
+        if (this.coverage) {
+            return true;
+        }
+        return false;
     }
-  }
-  hasCoverage() {
-    if (this.coverage) {
-      return true;
+    getCoverage() {
+        if(this.hasCoverage()) {
+            return (Math.round(this.coverage * 10) / 10).toString();
+        }
+        return "";
     }
-    return false;
-  }
-  getCoverage() {
-    if(this.hasCoverage()) {
-      return (Math.round(this.coverage * 10) / 10).toString();
+    getCoverageChange() {
+        if(this.hasCoverage()) {
+            return (Math.round(this.coverageChange * 10) / 10).toString();
+        }
+        return "";
     }
-    return "";
-  }
-  getCoverageChange() {
-    if(this.hasCoverage()) {
-      return (Math.round(this.coverageChange * 10) / 10).toString();
+    getNiceCoverage() {
+        var niceString = this.getCoverage();
+        if(niceString) {
+            return niceString + " %";
+        }
+        return "";
     }
-    return "";
-  }
-  getNiceCoverage() {
-    var niceString = this.getCoverage();
-    if(niceString) {
-      return niceString + " %";
+    getNiceCoverageChange() {
+        var niceString = this.getCoverageChange();
+        if(niceString) {
+            if(!niceString.includes("-"))
+                niceString = "+" + niceString;
+            return niceString + " %";
+        }
+        return "";
     }
-    return "";
-  }
-  getNiceCoverageChange() {
-    var niceString = this.getCoverageChange();
-    if(niceString) {
-      if(!niceString.includes("-"))
-        niceString = "+" + niceString;
-      return niceString + " %";
+    resetCoverallsInformation() {
+        this.coverage = null;
+        this.coverageChange = null;
     }
-    return "";
-  }
 
 }
 


### PR DESCRIPTION
Still concerning #14 
We now reset all status information (Travis, Sonarqube and Coveralls) if a branch was updated.
Therefore no outdated information should be shown now. In addition we now wait until the latest information are here to display them.